### PR TITLE
Update 2.install_cisco_nso_6.0_on_ubuntu_22.04_and_add_netsim_devices…

### DIFF
--- a/cisco_nso/2.install_cisco_nso_6.0_on_ubuntu_22.04_and_add_netsim_devices.txt
+++ b/cisco_nso/2.install_cisco_nso_6.0_on_ubuntu_22.04_and_add_netsim_devices.txt
@@ -148,6 +148,14 @@ show ip interface brief #does not work which is netsim limitation
 
 source $HOME/nso-6.0/ncsrc
 
+
+# or add it to the .bashrc file to make it permanent
+echo "source $HOME/nso-6.0/ncsrc" >> ~/.bashrc
+
+# refresh the current terminal
+source ~/.bashrc
+
+
 cd ~/nso-instance/
 ncs
 

--- a/cisco_nso/2.install_cisco_nso_6.0_on_ubuntu_22.04_and_add_netsim_devices.txt
+++ b/cisco_nso/2.install_cisco_nso_6.0_on_ubuntu_22.04_and_add_netsim_devices.txt
@@ -11,6 +11,7 @@ DISTRIB_DESCRIPTION="Ubuntu 22.04.1 LTS"
 !
 
 sudo apt-get install default-jdk
+sudo apt-get install openjdk-17-jdk openjdk-17-jre
 sudo apt-get install ant
 sudo apt-get install python3 python3-pip python3-setuptools
 sudo apt install libxml2-utils


### PR DESCRIPTION
Resolves (_NCS package upgrade failed with reason 'User java class "com.tailf.packages.ned.asa.UpgradeNedSettings" exited with status 1'
Daemon died status=13_) error when starting nso